### PR TITLE
Fix test tap output

### DIFF
--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -13,7 +13,7 @@ const transpile = require("./transpile");
 
 // The output of this program is processed by tap-xunit
 // Using console.log on stdout will break CI output
-// Use console.error instead.
+// Use tap.diag instead.
 tap.pipe(process.stdout)
 
 async function main() {
@@ -25,7 +25,7 @@ async function main() {
     throw new Error("If you really want to run all the tests, use\n\tnode lib/run-tests I_AM_SURE");
   }
 
-  console.error(`${chalk.gray("INFO")} Using ${agents.count} threads.`);
+  tap.diag(`${chalk.gray("INFO")} Using ${agents.count} threads.`);
 
   let passed = 0;
   let finished = 0;
@@ -64,9 +64,9 @@ async function main() {
 
   await agents.close();
 
-  console.error("\n\n");
-  console.error(`Run ${run} out of ${total} tests.`);
-  console.error(`Passed ${passed} out of ${run} tests.`);
+  tap.diag("\n\n");
+  tap.diag(`Run ${run} out of ${total} tests.`);
+  tap.diag(`Passed ${passed} out of ${run} tests.`);
 }
 main();
 

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -11,6 +11,9 @@ const TESTS = path.join(__dirname, "../../test262");
 const AgentPool = require("./agent-pool");
 const transpile = require("./transpile");
 
+// The output of this program is processed by tap-xunit
+// Using console.log on stdout will break CI output
+// Use console.error instead.
 tap.pipe(process.stdout)
 
 async function main() {
@@ -22,7 +25,7 @@ async function main() {
     throw new Error("If you really want to run all the tests, use\n\tnode lib/run-tests I_AM_SURE");
   }
 
-  console.log(`${chalk.gray("INFO")} Using ${agents.count} threads.`);
+  console.error(`${chalk.gray("INFO")} Using ${agents.count} threads.`);
 
   let passed = 0;
   let finished = 0;
@@ -61,9 +64,9 @@ async function main() {
 
   await agents.close();
 
-  console.log("\n\n");
-  console.log(`Run ${run} out of ${total} tests.`);
-  console.log(`Passed ${passed} out of ${run} tests.`);
+  console.error("\n\n");
+  console.error(`Run ${run} out of ${total} tests.`);
+  console.error(`Passed ${passed} out of ${run} tests.`);
 }
 main();
 


### PR DESCRIPTION
Outputting relevant output tends to break tap format. Replacing that with tap.diag instead.
<img width="1273" alt="Screen Shot 2019-09-27 at 2 48 19 PM" src="https://user-images.githubusercontent.com/2481105/65774323-e7cd0480-e135-11e9-9927-c85317d702ca.png">
