### PR TITLE
Add test timeout for slow tests

### DIFF
--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -8,6 +8,8 @@ const tap = require('make-tap-output')({ count: true });
 const NODE = path.join(__dirname, "../../engine/node/bin/node");
 const TESTS = path.join(__dirname, "../../test262");
 
+const TEST_TIMEOUT = 60 * 1000; // 1 minute
+
 const AgentPool = require("./agent-pool");
 const transpile = require("./transpile");
 
@@ -91,16 +93,29 @@ async function runTest(agent, test) {
   } catch (error) {
     return { result: "parser error", error };
   }
-
-  const result = await agent.evalScript({
-    attrs,
-    contents,
-    file: path.join(TESTS, file),
-  });
+  let result;
+  try {
+    result = await Promise.race([agent.evalScript({
+      attrs,
+      contents,
+      file: path.join(TESTS, file),
+    }), timeout(file)]);
+  } catch (error) {
+    return { result: "timeout error", error };
+  }
 
   if (result.error) {
     return { result: "runtime error", error: result.error };
   } else {
     return { result: "success", output: result.stdout };
   }
+}
+
+function timeout(file, waitMs = TEST_TIMEOUT) {
+  return new Promise(
+    (_resolve, reject) => setTimeout(
+        () => reject(new Error(`test ${file} timed out after ${waitMs} ms`)),
+        waitMs,
+      )
+    );
 }


### PR DESCRIPTION
The last run of babel test runner on babel/babel failed because of a test timeout which prevented output for 10 minutes on circle CI