### PR TITLE
Generate tap and xunit output for CircleCI

### DIFF
--- a/lib/run-tests/babel-agent-runtime.js
+++ b/lib/run-tests/babel-agent-runtime.js
@@ -70,6 +70,3 @@ var $ = {
   polyfills: $POLYFILLS,
 };
 
-function print() {
-  console.log.apply(console, arguments);
-}

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -67,7 +67,11 @@ async function main() {
   tap.diag("\n\n");
   tap.diag(`Run ${run} out of ${total} tests.`);
   tap.diag(`Passed ${passed} out of ${run} tests.`);
-  process.exit(0); // tap-mocha-reporter will output correct exit code
+  // Creating promises based timeouts per test prevents node from exiting
+  // causing an unparseable failure in CircleCI. Here we're forcing an exit
+  // with an exit code 0. tap-mocha-reporter will parse the tap output
+  // and output the correct exit code.
+  process.exit(0);
 }
 main();
 
@@ -122,25 +126,27 @@ function timeout(file, waitMs = TEST_TIMEOUT) {
 class ExtendedError extends Error {
   constructor(message) {
     super(message)
-    this.name = this.constructor.name
-    this.message = message
+    this.name = this.constructor.name;
+    this.message = message;
     if (typeof Error.captureStackTrace === 'function') {
-      Error.captureStackTrace(this, this.constructor)
+      Error.captureStackTrace(this, this.constructor);
     } else {
-      this.stack = (new Error(message)).stack
+      this.stack = (new Error(message)).stack;
     }
   }
 }
 
 class RethrownError extends ExtendedError {
-  constructor(error, message) {
-    const msg = message || error.message;
-    super(msg)
-    if (!error) throw new Error('RethrownError requires a message and error')
-    this.original = error
-    this.new_stack = this.stack
-    let message_lines = (this.message.match(/\n/g) || []).length + 1
-    this.stack = this.stack.split('\n').slice(0, message_lines + 1).join('\n') + '\n' +
-      error.stack.map(location => location.source).join('\n')
+  constructor(error) {
+    const message = error.message;
+    super(message);
+    this.name = error.name;
+    if (!error) throw new Error('RethrownError requires an error');
+    this.original = error;
+    this.new_stack = this.stack;
+    let message_lines = (this.message.match(/\n/g) || []).length + 1;
+    this.stack = `${this.name}: ${this.message}\n${
+      this.stack.split('\n').slice(0, message_lines + 1).join('\n')
+    }\n${error.stack.map(location => location.source).join('\n')}`;
   }
 }

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -67,7 +67,7 @@ async function main() {
   tap.diag("\n\n");
   tap.diag(`Run ${run} out of ${total} tests.`);
   tap.diag(`Passed ${passed} out of ${run} tests.`);
-  process.exit(!(passed === run));
+  process.exit(0); // tap-mocha-reporter will output correct exit code
 }
 main();
 

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -46,19 +46,17 @@ async function main() {
       const actual = await runTest(agent, test);
 
       finished++;
-
-      const file = `${test.file} ${chalk.blue(test.scenario)}`;
+      const file = `${test.file} ${test.scenario}`;
       const progress = `- ${finished}/${run}`
       if (actual.result === expected) {
         passed++;
         tap.pass(
-          `${chalk.green("PASS")} ${file} (${chalk.green(expected)}) ${progress}`,
-          actual.output
+          `${file} (${expected})`
         );
       } else {
         tap.fail(
-          `${chalk.red("FAIL")} ${file} (expected ${expected}, got ${chalk.red(actual.result)}) ${progress}`,
-          new Error(actual.error.message)
+          `${file} (expected ${expected}, got ${actual.result})`,
+          new RethrownError(actual.error)
         );
       }
     });
@@ -118,4 +116,30 @@ function timeout(file, waitMs = TEST_TIMEOUT) {
         waitMs,
       )
     );
+}
+
+class ExtendedError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = this.constructor.name
+    this.message = message
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor)
+    } else {
+      this.stack = (new Error(message)).stack
+    }
+  }
+}
+
+class RethrownError extends ExtendedError {
+  constructor(error, message) {
+    const msg = message || error.message;
+    super(msg)
+    if (!error) throw new Error('RethrownError requires a message and error')
+    this.original = error
+    this.new_stack = this.stack
+    let message_lines = (this.message.match(/\n/g) || []).length + 1
+    this.stack = this.stack.split('\n').slice(0, message_lines + 1).join('\n') + '\n' +
+      error.stack.map(location => location.source).join('\n')
+  }
 }

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -67,6 +67,7 @@ async function main() {
   tap.diag("\n\n");
   tap.diag(`Run ${run} out of ${total} tests.`);
   tap.diag(`Passed ${passed} out of ${run} tests.`);
+  process.exit(!(passed === run));
 }
 main();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -721,6 +721,14 @@
         "semver": "^5.5.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.6.2",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/runtime/-/runtime-7.6.2.tgz",
+      "integrity": "sha1-w9bkGzBO8Q3PE3d6M+dpTsSppt0=",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
@@ -783,6 +791,11 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -973,6 +986,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI="
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -1065,6 +1083,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -1227,6 +1250,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -1550,6 +1578,14 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
+    "minipass": {
+      "version": "3.0.1",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/minipass/-/minipass-3.0.1.tgz",
+      "integrity": "sha1-tP7HO9YeikDws3Td0EJgreLI7CA=",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1718,6 +1754,11 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -2048,12 +2089,69 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "tap-mocha-reporter": {
+      "version": "5.0.0",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/tap-mocha-reporter/-/tap-mocha-reporter-5.0.0.tgz",
+      "integrity": "sha1-q0ChaHuwuUHYDEPspMi2kDjvXW0=",
+      "requires": {
+        "color-support": "^1.1.0",
+        "debug": "^2.1.3",
+        "diff": "^1.3.2",
+        "escape-string-regexp": "^1.0.3",
+        "glob": "^7.0.5",
+        "readable-stream": "^2.1.5",
+        "tap-parser": "^10.0.0",
+        "tap-yaml": "^1.0.0",
+        "unicode-length": "^1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "tap-parser": {
+      "version": "10.0.0",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/tap-parser/-/tap-parser-10.0.0.tgz",
+      "integrity": "sha1-Sj6zYgpBtPthNrm8bweVVyPVauo=",
+      "requires": {
+        "events-to-array": "^1.0.1",
+        "minipass": "^3.0.0",
+        "tap-yaml": "^1.0.0"
+      }
+    },
+    "tap-yaml": {
+      "version": "1.0.0",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/tap-yaml/-/tap-yaml-1.0.0.tgz",
+      "integrity": "sha1-TjFEOlSJ4Fyou7PjbO9xtd7GljU=",
+      "requires": {
+        "yaml": "^1.5.0"
       }
     },
     "tar-fs": {
@@ -2177,6 +2275,15 @@
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
     },
+    "unicode-length": {
+      "version": "1.0.3",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/unicode-length/-/unicode-length-1.0.3.tgz",
+      "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+      "requires": {
+        "punycode": "^1.3.2",
+        "strip-ansi": "^3.0.1"
+      }
+    },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
@@ -2279,6 +2386,19 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+    },
+    "yaml": {
+      "version": "1.7.0",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/yaml/-/yaml-1.7.0.tgz",
+      "integrity": "sha1-tM3bg0kAUebEtv/iuwgiHCP0xs8=",
+      "requires": {
+        "@babel/runtime": "^7.5.5"
+      }
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "progress": "^2.0.3",
     "regenerator-runtime": "^0.13.3",
     "rimraf": "^3.0.0",
+    "tap-mocha-reporter": "^5.0.0",
     "targz": "^1.0.1",
     "tempy": "^0.3.0",
     "test262-stream": "^1.3.0"


### PR DESCRIPTION
## Summary of changes

1. Removes all the chalk output as it tends to break parsing.
   +  When running tests locally, maintainers can now use one of the `tap-mocha-reporters` to see the output in a human readable format. 
   + Here's a list of reporters: https://github.com/tapjs/tap-mocha-reporter/tree/master/lib/reporters
2. Ensures the original error stack is easily available to see in CircleCI and locally.
3. Ensure test runner does not hang in CI indefinitely.

Test Plan

1. Tested against https://github.com/babel/babel/pull/10500
   + Test results should show up here: https://app.circleci.com/jobs/github/babel/babel/11859/tests
   + Run: https://app.circleci.com/jobs/github/babel/babel/11859

#### `node --no-warnings lib/run-tests arrow-function | $(npm bin)/tap-mocha-reporter spec`

<img width="1003" alt="Screen Shot 2019-10-05 at 10 53 23 PM" src="https://user-images.githubusercontent.com/2481105/66263560-fa44df00-e7c2-11e9-95c2-e6996fd39bf4.png">

After tests finish, it'll collect all the errors with the stacktrace.

<img width="1055" alt="Screen Shot 2019-10-05 at 10 54 58 PM" src="https://user-images.githubusercontent.com/2481105/66263571-2f513180-e7c3-11e9-9fe7-4419ba6d1f63.png">