### PR TITLE
Cache config by features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 engine/
 
 node_modules/
+/.idea

--- a/lib/run-tests/ignored-tests.js
+++ b/lib/run-tests/ignored-tests.js
@@ -1,5 +1,5 @@
 module.exports = function shouldIgnore(test) {
   if (test.file.startsWith("test/intl402")) return true;
-  if (test.attrs.features.includes("Proxy")) return true;
+  if (test.attrs.features && test.attrs.features.includes("Proxy")) return true;
   return false;
 };

--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -1,15 +1,30 @@
 "use strict";
 
-const babel = require("@babel/core");
+const { default: loadConfig } = require("@babel/core/lib/config");
+const { runSync } = require("@babel/core/lib/transformation");
 const presetEnv = require("@babel/preset-env");
 
 const getBabelPlugins = require("./get-babel-plugins");
 
-module.exports = function transpile(code, features) {
-  return babel.transformSync(code, {
+const configCaches = new Map();
+
+function getOptions(features) {
+  const featureKey = JSON.stringify(features);
+  let config = configCaches.get(featureKey);
+  if (config !== undefined) {
+    return config;
+  }
+  config = loadConfig({
     configFile: false,
     presets: [[presetEnv, { spec: true }]],
     plugins: getBabelPlugins(features),
     sourceType: "script",
-  }).code;
+  });
+
+  configCaches.set(featureKey, config);
+  return config;
+}
+
+module.exports = function transpile(code, features) {
+  return runSync(getOptions(features), code).code;
 };

--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const { default: loadConfig } = require("@babel/core/lib/config");
-const { runSync } = require("@babel/core/lib/transformation");
+const { transformSync, loadOptions } = require("@babel/core");
 const presetEnv = require("@babel/preset-env");
 
 const getBabelPlugins = require("./get-babel-plugins");
@@ -14,7 +13,7 @@ function getOptions(features) {
   if (config !== undefined) {
     return config;
   }
-  config = loadConfig({
+  config = loadOptions({
     configFile: false,
     presets: [[presetEnv, { spec: true }]],
     plugins: getBabelPlugins(features),
@@ -26,5 +25,5 @@ function getOptions(features) {
 }
 
 module.exports = function transpile(code, features) {
-  return runSync(getOptions(features), code).code;
+  return transformSync(code, getOptions(features)).code;
 };


### PR DESCRIPTION
In this PR we improve the transpiler implementation by caching the configuration object. Compared to the master branch, the running time of `node lib/run-tests async-function` is reduced from 97s to 93s on my local machine.