### PR TITLE
Specify language tests in paths

### DIFF
--- a/lib/run-tests/ignored-tests.js
+++ b/lib/run-tests/ignored-tests.js
@@ -1,4 +1,0 @@
-module.exports = function shouldIgnore(test) {
-  if (!test.file.startsWith("test/language")) return true;
-  return false;
-};

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -11,7 +11,6 @@ const TEST_TIMEOUT = 60 * 1000; // 1 minute
 
 const AgentPool = require("./agent-pool");
 const transpile = require("./transpile");
-const shouldIgnore = require("./ignored-tests");
 
 // The output of this program is processed by tap-xunit
 // Using console.log on stdout will break CI output
@@ -20,7 +19,9 @@ tap.pipe(process.stdout);
 
 async function main() {
   const agents = new AgentPool(NODE);
-  const tests = new Test262Stream(TESTS);
+  const tests = new Test262Stream(TESTS, {
+    paths: ['test/language'],
+  });
 
   const filter = process.argv[2];
   if (!filter) {
@@ -39,11 +40,6 @@ async function main() {
     const file = `${test.file} ${test.scenario}`;
 
     if (filter !== "I_AM_SURE" && !test.file.includes(filter)) continue;
-
-    if (shouldIgnore(test)) {
-      tap.diag(`Ignoring ${test.file}.`);
-      continue;
-    }
 
     run++;
 


### PR DESCRIPTION
This shaves off more time for the run of the test262 job.

Instead of filtering out all the non-language tests, we can only choose to look into the tests that we care about.