### PR TITLE
Prevent comparision on CircleCI master

### DIFF
--- a/lib/compare-results/index.js
+++ b/lib/compare-results/index.js
@@ -2,12 +2,18 @@ const parser = require('@tap-format/parser')
 const path = require('path');
 const fs = require('fs');
 const _ = require('highland');
-
+const diag = console.log.bind(console, '# ');
 function throwIncorrectArgumentError() {
     throw new Error(`master branch and PR artifact file paths required
     Usage: node lib/compare-results master.tap test262.tap
     `);
 }
+
+console.log('TAP version 13');
+diag(`CIRCLECI = ${process.env.CIRCLECI}`);
+diag(`CIRCLE_BRANCH = ${process.env.CIRCLE_BRANCH}`);
+const isCircleCIMaster = process.env.CIRCLECI && process.env.CIRCLE_BRANCH === 'master';
+diag(`is CircleCI master branch job: ${isCircleCIMaster}`);
 
 function throwMasterArtifactOutOfSyncError() {
     throw new Error(`master branch and PR artifacts are out of sync. Was test262 sha updated in babel-test-runner?
@@ -41,17 +47,17 @@ async function main() {
         return acc;
     }, {});
     for (let i = 0; i < prTests.length; i++) {
-        const prTest = prTests[i];
-        if (!Object.prototype.hasOwnProperty.call(masterTestsMap, prTest.title)) {
-            console.log(`# Ignoring test '${prTest.title}' as it was not found in master artifact!`);
-            continue;
+        if (isCircleCIMaster) {
+            return;
         }
+        const prTest = prTests[i];
         const masterTest = masterTestsMap[prTest.title];
         switch (prTest.type) {
-            case 'version':
-                console.log(prTest.raw);
-                break;
             case 'assertion':
+                if (!Object.prototype.hasOwnProperty.call(masterTestsMap, prTest.title)) {
+                    diag(`Ignoring test '${prTest.title}' as it was not found in master artifact!`);
+                    continue;
+                }
                 if (prTest.ok !== masterTest.ok) {
                     console.log(prTest.raw);
                 }

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -52,11 +52,13 @@ async function main() {
       if (actual.result === expected) {
         passed++;
         tap.pass(
-          `${file} (${expected})`
+          file,
+          `(${expected})`
         );
       } else {
         tap.fail(
-          `${file} (expected ${expected}, got ${actual.result})`,
+          file,
+          `(expected ${expected}, got ${actual.result})`,
           new RethrownError(actual.error)
         );
       }


### PR DESCRIPTION
### Summary of changes

1. So it's quite tricky to conditionally running steps only on master or PR. Instead of going down that sparsely documented rabbithole, I've decided to cut my losses short and implement the conditional check inside node.
2. Failing tests on CircleCI were being ignored because they were causing cache miss from previous job. Luckily, I've updated the job to show comparison diagnostics, so it made things more obvious!