### PR TITLE
Properly compare test files between jobs

### DIFF
--- a/lib/compare-results/index.js
+++ b/lib/compare-results/index.js
@@ -21,7 +21,7 @@ function throwMasterArtifactOutOfSyncError() {
     `);
 }
 
-function getfileNameFromTitle(title) {
+function getFileNameFromTitle(title) {
     return title ?
         title.split('#')[0].trim() :
         undefined;
@@ -50,7 +50,7 @@ async function main() {
     }
     const masterTestsMap = masterTests.reduce((acc, test) =>  {
         if (test.type === 'assertion') {
-            acc[getfileNameFromTitle(test.title)] = test;
+            acc[getFileNameFromTitle(test.title)] = test;
         }
         return acc;
     }, Object.create(null));
@@ -60,7 +60,7 @@ async function main() {
             return;
         }
         const prTest = prTests[i];
-        const fileName = getfileNameFromTitle(prTest.title);
+        const fileName = getFileNameFromTitle(prTest.title);
         const masterTest = masterTestsMap[fileName];
         switch (prTest.type) {
             case 'assertion':

--- a/lib/compare-results/index.js
+++ b/lib/compare-results/index.js
@@ -21,6 +21,12 @@ function throwMasterArtifactOutOfSyncError() {
     `);
 }
 
+function getfileNameFromTitle(title) {
+    return title ?
+        title.split('#')[0].trim() :
+        undefined;
+}
+
 function parseTestResults(filePath) {
     return new Promise(resolve => _(fs.createReadStream(filePath).pipe(parser.stream()))
         .map(buffer => JSON.parse(buffer.toString()))
@@ -43,19 +49,23 @@ async function main() {
         throwMasterArtifactOutOfSyncError();
     }
     const masterTestsMap = masterTests.reduce((acc, test) =>  {
-        acc[test.title] = test;
+        if (test.type === 'assertion') {
+            acc[getfileNameFromTitle(test.title)] = test;
+        }
         return acc;
-    }, {});
+    }, Object.create(null));
+
     for (let i = 0; i < prTests.length; i++) {
         if (isCircleCIMaster) {
             return;
         }
         const prTest = prTests[i];
-        const masterTest = masterTestsMap[prTest.title];
+        const fileName = getfileNameFromTitle(prTest.title);
+        const masterTest = masterTestsMap[fileName];
         switch (prTest.type) {
             case 'assertion':
-                if (!Object.prototype.hasOwnProperty.call(masterTestsMap, prTest.title)) {
-                    diag(`Ignoring test '${prTest.title}' as it was not found in master artifact!`);
+                if (!(fileName in masterTestsMap)) {
+                    diag(`Ignoring test '${fileName}' as it was not found in master artifact!`);
                     continue;
                 }
                 if (prTest.ok !== masterTest.ok) {

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -92,9 +92,10 @@ function getExpected({ attrs }) {
 
 async function runTest(agent, test) {
   let { attrs, contents, file } = test;
+  const isModule = attrs.flags.module;
 
   try {
-    contents = transpile(contents, attrs.features);
+    contents = transpile(contents, attrs.features, isModule);
   } catch (error) {
     return { result: "parser error", error };
   }
@@ -146,9 +147,11 @@ class RethrownError extends ExtendedError {
     if (!error) throw new Error('RethrownError requires an error');
     this.original = error;
     this.new_stack = this.stack;
+    const errorStackString = error.stack && (typeof error.stack === 'string' ?
+      error.stack : error.stack.map(location => location.source).join('\n'));
     let message_lines = (this.message.match(/\n/g) || []).length + 1;
     this.stack = `${this.name}: ${this.message}\n${
       this.stack.split('\n').slice(0, message_lines + 1).join('\n')
-    }\n${error.stack.map(location => location.source).join('\n')}`;
+      }\n${errorStackString}`;
   }
 }

--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -7,7 +7,7 @@ const getBabelPlugins = require("./get-babel-plugins");
 
 const configCaches = new Map();
 
-function getOptions(features) {
+function getOptions(features, isModule) {
   const featureKey = JSON.stringify(features);
   let config = configCaches.get(featureKey);
   if (config !== undefined) {
@@ -17,13 +17,13 @@ function getOptions(features) {
     configFile: false,
     presets: [[presetEnv, { spec: true }]],
     plugins: getBabelPlugins(features),
-    sourceType: "script",
+    sourceType: isModule ? "module" : "script",
   });
 
   configCaches.set(featureKey, config);
   return config;
 }
 
-module.exports = function transpile(code, features) {
-  return transformSync(code, getOptions(features)).code;
+module.exports = function transpile(code, features, isModule) {
+  return transformSync(code, getOptions(features, isModule)).code;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1606,9 +1606,9 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
-      "version": "3.0.1",
-      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/minipass/-/minipass-3.0.1.tgz",
-      "integrity": "sha1-tP7HO9YeikDws3Td0EJgreLI7CA=",
+      "version": "3.1.1",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/minipass/-/minipass-3.1.1.tgz",
+      "integrity": "sha1-dgfOd4RyoYWtbYkIKqIHD3nO3NU=",
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -2158,6 +2158,14 @@
         "has-flag": "^3.0.0"
       }
     },
+    "tap-merge": {
+      "version": "0.3.1",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/tap-merge/-/tap-merge-0.3.1.tgz",
+      "integrity": "sha1-H7vaGwngLb193YzU7fi5utEYSpE=",
+      "requires": {
+        "highland": "^2.5.1"
+      }
+    },
     "tap-mocha-reporter": {
       "version": "5.0.0",
       "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/tap-mocha-reporter/-/tap-mocha-reporter-5.0.0.tgz",
@@ -2190,9 +2198,9 @@
       }
     },
     "tap-parser": {
-      "version": "10.0.0",
-      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/tap-parser/-/tap-parser-10.0.0.tgz",
-      "integrity": "sha1-Sj6zYgpBtPthNrm8bweVVyPVauo=",
+      "version": "10.0.1",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/tap-parser/-/tap-parser-10.0.1.tgz",
+      "integrity": "sha1-tjwlAO7vK+j78J1RKRQZbR8S6+w=",
       "requires": {
         "events-to-array": "^1.0.1",
         "minipass": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "progress": "^2.0.3",
     "regenerator-runtime": "^0.13.3",
     "rimraf": "^3.0.0",
+    "tap-merge": "^0.3.1",
     "tap-mocha-reporter": "^5.0.0",
     "targz": "^1.0.1",
     "tempy": "^0.3.0",


### PR DESCRIPTION
### Summary of changes

+ With the help of the previous PR #16, I've been able to compare a master branch and my PR branch artifacts (by downloading them locally) and figuring out what are the remaining issues.
   + As you can see, it is correctly erroring on test failures my PR is causing.
   + I'm guessing the success values are coming from the fact that my babel PR is a month old and something else might have been fixed along the way. Now, I'll update my main PR and see if these errors remain.

But this is great progress.


```
➜ CIRCLE_BRANCH=PR/1234 node lib/compare-results master.tap test262.tap | $(npm bin)/tap-merge
TAP version 13
#  CIRCLECI = undefined
#  CIRCLE_BRANCH = PR/1234
#  is CircleCI master branch job: undefined
not ok 1 test/language/expressions/arrow-function/prototype-rules.js default # (expected success, got runtime error)
  ---
  name: Test262Error
  message: 'Expected SameValue(«true», «false») to be true'
  stack: |
    Test262Error: Expected SameValue(«true», «false») to be true
    /home/circleci/babel/babel-test262-runner/lib/run-tests/index.js:62:11

  ...
not ok 2 test/language/expressions/arrow-function/prototype-rules.js strict mode # (expected success, got runtime error)
  ---
  name: Test262Error
  message: 'Expected SameValue(«true», «false») to be true'
  stack: |
    Test262Error: Expected SameValue(«true», «false») to be true
    /home/circleci/babel/babel-test262-runner/lib/run-tests/index.js:62:11

  ...
not ok 3 test/language/expressions/arrow-function/throw-new.js strict mode # (expected success, got runtime error)
  ---
  name: Test262Error
  message: Expected a TypeError to be thrown but no exception was thrown at all
  stack: >
    Test262Error: Expected a TypeError to be thrown but no exception was thrown at
    all

    /home/circleci/babel/babel-test262-runner/lib/run-tests/index.js:62:11

  ...
not ok 4 test/language/expressions/arrow-function/throw-new.js default # (expected success, got runtime error)
  ---
  name: Test262Error
  message: Expected a TypeError to be thrown but no exception was thrown at all
  stack: >
    Test262Error: Expected a TypeError to be thrown but no exception was thrown at
    all

    /home/circleci/babel/babel-test262-runner/lib/run-tests/index.js:62:11

  ...
ok 5 test/language/literals/regexp/u-invalid-optional-lookbehind.js default # (parser error)

ok 6 test/language/literals/regexp/u-invalid-optional-lookbehind.js strict mode # (parser error)

ok 7 test/language/literals/regexp/u-invalid-optional-negative-lookbehind.js default # (parser error)

ok 8 test/language/literals/regexp/u-invalid-optional-negative-lookbehind.js strict mode # (parser error)

ok 9 test/language/literals/regexp/u-invalid-range-lookbehind.js default # (parser error)

ok 10 test/language/literals/regexp/u-invalid-range-lookbehind.js strict mode # (parser error)

ok 11 test/language/literals/regexp/u-invalid-range-negative-lookbehind.js default # (parser error)

ok 12 test/language/literals/regexp/u-invalid-range-negative-lookbehind.js strict mode # (parser error)

not ok 13 test/language/computed-property-names/class/method/symbol.js strict mode # (expected success, got runtime error)
  ---
  name: Test262Error
  message: >-
    `compareArray(Object.getOwnPropertyNames(C.prototype), ['constructor', 'a',
    'c'])` returns `true`
  stack: >
    Test262Error: `compareArray(Object.getOwnPropertyNames(C.prototype),
    ['constructor', 'a', 'c'])` returns `true`

    /home/circleci/babel/babel-test262-runner/lib/run-tests/index.js:62:11

  ...
ok 14 test/language/literals/regexp/named-groups/invalid-identity-escape-in-capture-u.js default # (parser error)

ok 15 test/language/literals/regexp/named-groups/invalid-identity-escape-in-capture-u.js strict mode # (parser error)

ok 16 test/language/literals/regexp/named-groups/invalid-incomplete-groupname-2-u.js default # (parser error)

ok 17 test/language/literals/regexp/named-groups/invalid-incomplete-groupname-2-u.js strict mode # (parser error)

ok 18 test/language/literals/regexp/named-groups/invalid-incomplete-groupname-u.js default # (parser error)

ok 19 test/language/literals/regexp/named-groups/invalid-incomplete-groupname-u.js strict mode # (parser error)


0..0
```