### PR TITLE
disable code highlighting on error frame

### DIFF
--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -18,6 +18,7 @@ function getOptions(features, isModule) {
     presets: [[presetEnv, { spec: true }]],
     plugins: getBabelPlugins(features),
     sourceType: isModule ? "module" : "script",
+    highlightCode: false,
   });
 
   configCaches.set(configKey, config);

--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -8,8 +8,8 @@ const getBabelPlugins = require("./get-babel-plugins");
 const configCaches = new Map();
 
 function getOptions(features, isModule) {
-  const featureKey = JSON.stringify(features);
-  let config = configCaches.get(featureKey);
+  const configKey = JSON.stringify({ features, isModule });
+  let config = configCaches.get(configKey);
   if (config !== undefined) {
     return config;
   }
@@ -20,7 +20,7 @@ function getOptions(features, isModule) {
     sourceType: isModule ? "module" : "script",
   });
 
-  configCaches.set(featureKey, config);
+  configCaches.set(configKey, config);
   return config;
 }
 


### PR DESCRIPTION
This PR fixes invalid config cache when `isModule` is changed. In addition, the `highlightCode` is toggled off for performance.