### PR TITLE
Make output valid tap for ci processing

### DIFF
--- a/lib/compare-results/index.js
+++ b/lib/compare-results/index.js
@@ -55,6 +55,7 @@ async function main() {
         return acc;
     }, Object.create(null));
 
+    let count = 0;
     for (let i = 0; i < prTests.length; i++) {
         if (isCircleCIMaster) {
             return;
@@ -69,11 +70,13 @@ async function main() {
                     continue;
                 }
                 if (prTest.ok !== masterTest.ok) {
+                    ++count;
                     console.log(prTest.raw);
                 }
                 break;
         }
     }
+    console.log(`1..${count}`);
 }
 
 main();


### PR DESCRIPTION
### Summary of changes

1. It turns out that the `diff.tap` we've been using so far was not valid output because it didn't have a plan. This PR adds that at the end. Tested with `tap-parser` and it didn't report the error anymore.