### PR TITLE
Print previous master build for debugging

### DIFF
--- a/lib/download-master-artifact/index.js
+++ b/lib/download-master-artifact/index.js
@@ -38,6 +38,12 @@ async function findTest262Artifact(buildNums) {
         const buildArtifacts = await getJSONData(`${CIRCLECI_BABEL_API}/${buildNum}/artifacts`);
         const test262Artifact = buildArtifacts.find((artifact => artifact.path === TEST262_ARTIFACT_PATH));
         if (test262Artifact) {
+            console.log(`Previous master build: ${buildNum}`);
+            console.log(`Previous build link: https://app.circleci.com/jobs/github/babel/babel/${buildNum}`);
+            console.log(`Previous build artifacts: https://app.circleci.com/jobs/github/babel/babel/${buildNum}/artifacts`);
+            const test262ArtifactUrl = test262Artifact.url;
+            console.log(`Previous build test262 artifact: ${test262ArtifactUrl}`);
+
             return getTextData(test262Artifact.url);
         }
     }


### PR DESCRIPTION
### Summary of changes

1. The goal of this changeset is to facilitate easier debugging of test262 errors in CI

```
babel-test262-runner on  print-previous-master-build [$!?] is 📦 v1.0.0 via ⬢ v10.0.0 took 2s
➜ node lib/download-master-artifact
Calling CircleCI API: https://circleci.com/api/v1.1/project/github/babel/babel/tree/master
Previous master build: 12471
Previous build link: https://app.circleci.com/jobs/github/babel/babel/12471
Previous build artifacts: https://app.circleci.com/jobs/github/babel/babel/12471/artifacts
Previous build test262 artifact: https://12471-24560307-gh.circle-artifacts.com/0/home/circleci/test262.tap
Successfully saved master artifact at: /Users/jbhoosreddy/Projects/babel-test262-runner/master.tap
```