### PR TITLE
Add skip file for intermittent tests

### DIFF
--- a/intermittent-tests.txt
+++ b/intermittent-tests.txt
@@ -1,0 +1,2 @@
+test/language/computed-property-names/basics/symbol.js default
+test/language/computed-property-names/class/method/symbol.js default

--- a/lib/run-tests/filter-intermittent-tests.js
+++ b/lib/run-tests/filter-intermittent-tests.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+
+const intermittentTests = fs.readFileSync(`${__dirname}/../../intermittent-tests.txt`, 'utf-8')
+    .trim()
+    .split(/\r?\n/);
+
+module.exports = function filterIntermittentTests(file) {
+    return intermittentTests.includes(file);
+}

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -9,6 +9,8 @@ const TESTS = path.join(__dirname, "../../test262");
 
 const TEST_TIMEOUT = 60 * 1000; // 1 minute
 
+const filterIntermittentTests = require('./filter-intermittent-tests');
+
 const AgentPool = require("./agent-pool");
 const transpile = require("./transpile");
 
@@ -40,6 +42,7 @@ async function main() {
     const file = `${test.file} ${test.scenario}`;
 
     if (filter !== "I_AM_SURE" && !test.file.includes(filter)) continue;
+    if (filterIntermittentTests(file)) continue;
 
     run++;
 


### PR DESCRIPTION
### Summary of changes

1. So we noticed that there are some tests which are intermittent. As requested, adding a skip list of tests which can be ignored if they are intermittent.