### PR TITLE
Compare different lengths of test results

### DIFF
--- a/lib/compare-results/index.js
+++ b/lib/compare-results/index.js
@@ -46,15 +46,17 @@ async function main() {
         const prTest = prTests[i];
         const fileName = getFileNameFromTitle(prTest.title);
         if (prTest.type === 'assertion') {
-            if (!(fileName in masterTestsMap)) {
+            if (fileName in masterTestsMap) {
+                const masterTest = masterTestsMap[fileName];
+                if (prTest.ok !== masterTest.ok) {
+                    ++count;
+                    // This reports existing tests which changed result
+                    console.log(prTest.raw);
+                }
+            }
+            else {
                 // This reports new tests which were not seen previously
                 // whether they are passing/failing
-                console.log(prTest.raw);
-            }
-            const masterTest = masterTestsMap[fileName];
-            if (prTest.ok !== masterTest.ok) {
-                ++count;
-                // This reports existing tests which changed result
                 console.log(prTest.raw);
             }
         }

--- a/lib/compare-results/index.js
+++ b/lib/compare-results/index.js
@@ -11,12 +11,6 @@ function throwIncorrectArgumentError() {
 
 console.log('TAP version 13');
 
-function throwMasterArtifactOutOfSyncError() {
-    throw new Error(`master branch and PR artifacts are out of sync. Was test262 sha updated in babel-test-runner?
-    Consider re-running the master branch test262 job to update the master branch artifact first!
-    `);
-}
-
 function getFileNameFromTitle(title) {
     return title ?
         title.split('#')[0].trim() :
@@ -40,10 +34,6 @@ async function main() {
 
     const [masterTests, prTests] = await Promise.all([parseTestResults(masterArtifactFilePath), parseTestResults(prArtifactFilePath)]);
 
-    if (masterTests.length !== prTests.length) {
-        console.error('Master and PR artifacts out of sync! Reason: Different number of tests.');
-        throwMasterArtifactOutOfSyncError();
-    }
     const masterTestsMap = masterTests.reduce((acc, test) =>  {
         if (test.type === 'assertion') {
             acc[getFileNameFromTitle(test.title)] = test;
@@ -55,18 +45,18 @@ async function main() {
     for (let i = 0; i < prTests.length; i++) {
         const prTest = prTests[i];
         const fileName = getFileNameFromTitle(prTest.title);
-        const masterTest = masterTestsMap[fileName];
-        switch (prTest.type) {
-            case 'assertion':
-                if (!(fileName in masterTestsMap)) {
-                    diag(`Ignoring test '${fileName}' as it was not found in master artifact!`);
-                    continue;
-                }
-                if (prTest.ok !== masterTest.ok) {
-                    ++count;
-                    console.log(prTest.raw);
-                }
-                break;
+        if (prTest.type === 'assertion') {
+            if (!(fileName in masterTestsMap)) {
+                // This reports new tests which were not seen previously
+                // whether they are passing/failing
+                console.log(prTest.raw);
+            }
+            const masterTest = masterTestsMap[fileName];
+            if (prTest.ok !== masterTest.ok) {
+                ++count;
+                // This reports existing tests which changed result
+                console.log(prTest.raw);
+            }
         }
     }
     console.log(`1..${count}`);


### PR DESCRIPTION
### Summary of changes

1. Currently, when comparing two lists of test cases of different lengths, the test runner bails. This was not so much of an issue before but now with the intermittent-tests.txt file, the numbers can change even if the test262 commit is the same. This changeset modifies the comparison behavior to accommodate different lengths of tests.