### PR TITLE
Use bail out instead of throw

### DIFF
--- a/lib/compare-results/index.js
+++ b/lib/compare-results/index.js
@@ -3,18 +3,12 @@ const path = require('path');
 const fs = require('fs');
 const _ = require('highland');
 const diag = console.log.bind(console, '# ');
-function throwIncorrectArgumentError() {
-    throw new Error(`master branch and PR artifact file paths required
-    Usage: node lib/compare-results master.tap test262.tap
-    `);
-}
 
 console.log('TAP version 13');
 
-function throwMasterArtifactOutOfSyncError() {
-    throw new Error(`master branch and PR artifacts are out of sync. Was test262 sha updated in babel-test-runner?
-    Consider re-running the master branch test262 job to update the master branch artifact first!
-    `);
+function bailOut(reason) {
+    console.log(`Bail out! ${reason}`);
+    process.exit(0); // tap-mocha-reporter will report correct failure code to CircleCI
 }
 
 function getFileNameFromTitle(title) {
@@ -33,7 +27,7 @@ async function main() {
     const masterArtifactFileArg = process.argv[2];
     const prArtifactFileArg = process.argv[3];
     if (!(masterArtifactFileArg && prArtifactFileArg)) {
-        throwIncorrectArgumentError();
+        bailOut(`master branch and PR artifact file paths required. Usage: node lib/compare-results master.tap test262.tap`);
     }
     const masterArtifactFilePath = path.resolve(process.cwd(), masterArtifactFileArg);
     const prArtifactFilePath = path.resolve(process.cwd(), prArtifactFileArg);
@@ -41,8 +35,7 @@ async function main() {
     const [masterTests, prTests] = await Promise.all([parseTestResults(masterArtifactFilePath), parseTestResults(prArtifactFilePath)]);
 
     if (masterTests.length !== prTests.length) {
-        console.error('Master and PR artifacts out of sync! Reason: Different number of tests.');
-        throwMasterArtifactOutOfSyncError();
+        bailOut(`master branch and PR artifacts are out of sync. Possible reasons include intermittent-tests.txt or test262 sha was updated. Consider re-running the master branch test262 job to update the master branch artifact first!`);
     }
     const masterTestsMap = masterTests.reduce((acc, test) =>  {
         if (test.type === 'assertion') {


### PR DESCRIPTION
### Summary of changes

1. Currently, there are 2 reason the comparison will bail out. a) incorrect args and b) different length of tests.
2. When this happens, the circle CI output shows no test failure which may be fine since no test262 tests were run. But even looking at diff.tap only shows `TAP version 13`. The only way to see what happened is to sift through the logs.

With this change:
diff.tap should look like:
```
TAP version 13
Bail out! master branch and PR artifacts are out of sync. Possible reasons include intermittent-tests.txt or test262 sha was updated. Consider re-running the master branch test262 job to update the master branch artifact first!

0..0
```

This will still report it as an error in CircleCI job.

ref: https://testanything.org/tap-version-13-specification.html

```
node lib/compare-results master.tap test262.tap | $(npm bin)/tap-merge | $(npm bin)/tap-mocha-reporter xunit
<testsuite name="TAP Tests" tests="0" failures="0" errors="0" skipped="0" timestamp="Thu, 21 Nov 2019 13:50:26 GMT" time="9.568">
</testsuite>

babel-test262-runner on  master [$!?] is 📦 v1.0.0 via ⬢ v10.0.0 took 11s
➜ echo $?
1
```