### PR TITLE
feat: transform babel parser error to eval-able SyntaxError

### DIFF
--- a/lib/run-tests/plugins/transform-eval.js
+++ b/lib/run-tests/plugins/transform-eval.js
@@ -13,8 +13,17 @@ module.exports = function ({ types: t }) {
 
         const arg = node.arguments[0];
         if (!t.isStringLiteral(arg)) return;
-
-        arg.value = transpile(arg.value);
+        try {
+          arg.value = transpile(arg.value);
+        } catch (e) {
+          if (e.code === "BABEL_PARSE_ERROR") {
+            // transform `eval("const invalid")` to `eval("throw new SyntaxError()")`
+            arg.value = "throw new SyntaxError()";
+          } else {
+            // todo: Can we construct TypeError / ReferenceError from the raw error message?
+            arg.value = "throw new Error()"
+          }
+        }
       },
     },
   };


### PR DESCRIPTION
Some test262 tests uses `eval` to make assertions on SyntaxError. i.e.

https://github.com/tc39/test262/blob/d9740c172652d36194ceae3ed3d0484e9968ebc3/test/language/eval-code/direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js#L14

However the `transform-eval` plugin will result to a parsing error and the tests are thus failed. This PR ensures that `transform-eval` always succeed. The output of `transform-eval` can be `throw new Error()` if transpiling throws.