### PR TITLE
Add import attributes plugin

### DIFF
--- a/lib/run-tests/get-babel-plugins.js
+++ b/lib/run-tests/get-babel-plugins.js
@@ -10,6 +10,10 @@ const featuresToPlugins = {
   "regexp-duplicate-named-groups": requireBabel(
     "@babel/plugin-proposal-duplicate-named-capturing-groups-regex"
   ),
+  "import-attributes": [
+    requireBabel("@babel/plugin-syntax-import-attributes"),
+    { "deprecatedAssertSyntax": true }
+  ]
 };
 
 const defaultPlugins = [
@@ -18,6 +22,7 @@ const defaultPlugins = [
 ];
 
 const aliases = {
+  "import-assertions": "import-attributes",
   // "class-fields-private": "class-fields-public",
   // "class-static-fields-public": "class-fields-public",
   // "class-static-fields-private": "class-fields-public",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/core": "^7.22.1",
         "@babel/plugin-proposal-decorators": "^7.22.3",
         "@babel/plugin-proposal-duplicate-named-capturing-groups-regex": "^7.22.3",
+        "@babel/plugin-syntax-import-attributes": "^7.22.3",
         "@babel/preset-env": "^7.22.4",
         "@octokit/core": "^4.0.5",
         "@tap-format/parser": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/core": "^7.22.1",
     "@babel/plugin-proposal-decorators": "^7.22.3",
     "@babel/plugin-proposal-duplicate-named-capturing-groups-regex": "^7.22.3",
+    "@babel/plugin-syntax-import-attributes": "^7.22.3",
     "@babel/preset-env": "^7.22.4",
     "@octokit/core": "^4.0.5",
     "@tap-format/parser": "^0.2.1",


### PR DESCRIPTION
Add missing import attributes Babel plugin for existing import assertions tests and future import attributes tests.