### PR TITLE
Add `"use strict"` to `transpile` for direct eval

### DIFF
--- a/lib/compare-results/index.js
+++ b/lib/compare-results/index.js
@@ -35,7 +35,7 @@ async function main() {
     const [mainTests, prTests] = await Promise.all([parseTestResults(mainArtifactFilePath), parseTestResults(prArtifactFilePath)]);
 
     if (mainTests.length !== prTests.length) {
-        diag(`main branch and PR artifacts are out of sync. Consider rebaing the PR.`);
+        diag(`main branch and PR artifacts are out of sync. Consider rebasing the PR.`);
     }
     const mainTestsMap = mainTests.reduce((acc, test) =>  {
         if (test.type === 'assertion') {
@@ -46,6 +46,7 @@ async function main() {
 
     let newFailures = 0;
     let newSuccesses = 0;
+    let totalSuccesses = 0;
     for (let i = 0; i < prTests.length; i++) {
         const prTest = prTests[i];
         const fileName = getFileNameFromTitle(prTest.title);
@@ -56,6 +57,7 @@ async function main() {
                     diag(`Ignoring test '${fileName}' as it was not found in main artifact!`);
                     continue;
                 }
+                if(prTest.ok) totalSuccesses++;
                 if (prTest.ok !== mainTest.ok) {
                     if (prTest.ok) newSuccesses++;
                     else newFailures++;
@@ -64,6 +66,7 @@ async function main() {
                 break;
         }
     }
+    console.log(`# ${prTests.length} tests, ${totalSuccesses} successes`);
     console.log(`# ${newFailures} new failures, ${newSuccesses} new successes`);
     console.log(`1..${newFailures + newSuccesses}`);
 

--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -14,8 +14,8 @@ const getBabelPlugins = require("./get-babel-plugins");
 
 const configCaches = new Map();
 
-function getOptions(features, isModule, isStrict) {
-  const configKey = JSON.stringify({ features, isModule, isStrict });
+function getOptions(features, isModule) {
+  const configKey = JSON.stringify({ features, isModule });
   let config = configCaches.get(configKey);
   if (config !== undefined) {
     return config;
@@ -27,7 +27,6 @@ function getOptions(features, isModule, isStrict) {
     sourceType: isModule ? "module" : "script",
     highlightCode: false,
     generatorOpts: { minified: true },
-    parserOpts: { strictMode: isStrict }
   });
 
   configCaches.set(configKey, config);
@@ -35,6 +34,9 @@ function getOptions(features, isModule, isStrict) {
 }
 
 module.exports = function transpile(code, { features, isModule, isStrict } = {}) {
-  const ret = transformSync(code, getOptions(features || [], Boolean(isModule), Boolean(isStrict))).code;
+  if (isStrict && !isModule && !/^\s*['"]use strict['"]/.test(code)) {
+    code = `"use strict";\n${code}`;
+  }
+  const ret = transformSync(code, getOptions(features || [], Boolean(isModule))).code;
   return ret;
 };


### PR DESCRIPTION
I tested this fixes the failure in https://github.com/babel/babel/pull/16398.

This may also affect things other than `eval`, but should be fine.