### PR TITLE
Add running result cache

### DIFF
--- a/lib/download-main-artifact/index.mjs
+++ b/lib/download-main-artifact/index.mjs
@@ -9,7 +9,7 @@ const {
     REPO_NAME = 'babel',
     BRANCH = 'main',
     WORKFLOW_NAME = 'ci.yml',
-    ARTIFACT_NAME = 'test262-result',
+    ARTIFACT_NAME = process.argv[3] ?? 'test262-result',
     ARTIFACT_FILE = 'test262.tap',
 } = process.env;
 

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -11,7 +11,7 @@ const NODE = path.join(__dirname, "../../engine/node/bin/node");
 const TESTS = process.env.TEST262_PATH
   ? relative(process.env.TEST262_PATH)
   : path.join(__dirname, "../../test262");
-const THREADS = Number(process.env.THREADS) || require("os").cpus().length / 2;
+const THREADS = Number(process.env.THREADS) || require("os").cpus().length;
 const { CHUNK, CHUNKS_FILE } = process.env;
 
 const chunk = CHUNKS_FILE

--- a/lib/run-tests/index.js
+++ b/lib/run-tests/index.js
@@ -21,7 +21,6 @@ const chunk = CHUNKS_FILE
 const worker = new JestWorker(require.resolve("./worker"), {
   numWorkers: THREADS,
   exposedMethods: ["runTest"],
-  enableWorkerThreads: true,
   setupArgs: [{ hostPath: NODE, shortName: "$262", testRoot: TESTS }],
 });
 worker.getStdout().pipe(process.stdout);

--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -4,7 +4,7 @@ const requireBabel = require("./contextualize-require");
 /**
  * @type {import("@babel/core")}
  */
-const { transformSync, loadOptions } = requireBabel("@babel/core");
+const { transformSync, loadOptionsSync } = requireBabel("@babel/core");
 /**
  * @type {import("@babel/preset-env")}
  */
@@ -20,9 +20,15 @@ function getOptions(features, isModule) {
   if (config !== undefined) {
     return config;
   }
-  config = loadOptions({
+  config = loadOptionsSync({
     configFile: false,
-    presets: [[presetEnv, { spec: true }]],
+    babelrc: false,
+    targets: ">= 0%",
+    presets: [presetEnv],
+    // spec
+    assumptions: {
+      noNewArrows: false,
+    },
     plugins: getBabelPlugins(features),
     sourceType: isModule ? "module" : "script",
     highlightCode: false,

--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -26,18 +26,24 @@ function getOptions(features, isModule) {
     plugins: getBabelPlugins(features),
     sourceType: isModule ? "module" : "script",
     highlightCode: false,
-    generatorOpts: { minified: true },
+    generatorOpts: { compact: true },
   });
 
   configCaches.set(configKey, config);
   return config;
 }
 
-module.exports = function transpile(code, { features, isModule, isStrict } = {}) {
+module.exports = function transpile(
+  code,
+  { features, isModule, isStrict } = {}
+) {
   if (isStrict && !isModule && !/^\s*['"]use strict['"]/.test(code)) {
     // eval("") === undefined
     code = `"use strict";\nundefined;\n${code}`;
   }
-  const ret = transformSync(code, getOptions(features || [], Boolean(isModule))).code;
+  const ret = transformSync(
+    code,
+    getOptions(features || [], Boolean(isModule))
+  ).code;
   return ret;
 };

--- a/lib/run-tests/worker.js
+++ b/lib/run-tests/worker.js
@@ -48,7 +48,7 @@ let agent, testRoot, cacheDB;
 exports.setup = function (opts) {
   agent = new BabelAgent(opts);
   testRoot = opts.testRoot;
-  cacheDB = new lmdb.open("cache.lmdb", {
+  cacheDB = new lmdb.open(path.join(__dirname, "cache.lmdb"), {
     compression: true,
   });
 };

--- a/lib/run-tests/worker.js
+++ b/lib/run-tests/worker.js
@@ -48,7 +48,7 @@ let agent, testRoot, cacheDB;
 exports.setup = function (opts) {
   agent = new BabelAgent(opts);
   testRoot = opts.testRoot;
-  cacheDB = new lmdb.open(path.join(__dirname, "cache.lmdb"), {
+  cacheDB = new lmdb.open(path.join(__dirname, "../../cache.lmdb"), {
     compression: true,
   });
 };

--- a/lib/run-tests/worker.js
+++ b/lib/run-tests/worker.js
@@ -1,9 +1,38 @@
 const path = require("path");
+const crypto = require("crypto");
+const lmdb = require("lmdb");
+
+const dependencies = require("eshost/lib/dependencies");
 
 const BabelAgent = require("./babel-agent");
 const transpile = require("./transpile");
 
 const TEST_TIMEOUT = 60 * 1000; // 1 minute
+
+function sha1(str) {
+  return crypto.createHash("sha1").update(str, "utf8").digest("hex");
+}
+
+function buildCacheHash(test) {
+  let { phase = "", type = "" } = test.attrs.negative || {};
+  if ((phase === "early" || phase === "parse") && type === "SyntaxError") {
+    return sha1(test.contents);
+  }
+  const sources = dependencies
+    .getDependencies(test.file)
+    .sort()
+    .map(function (file) {
+      if (file === path.basename(test.file)) {
+        return;
+      }
+      return dependencies.rawSource.get(path.basename(file));
+    })
+    .filter(Boolean);
+
+  sources.push(test.contents);
+
+  return sha1(sources.join("\n"));
+}
 
 function timeout(file, waitMs = TEST_TIMEOUT) {
   return new Promise((_resolve, reject) =>
@@ -14,45 +43,62 @@ function timeout(file, waitMs = TEST_TIMEOUT) {
   );
 }
 
-let agent, testRoot;
+let agent, testRoot, cacheDB;
 
 exports.setup = function (opts) {
   agent = new BabelAgent(opts);
   testRoot = opts.testRoot;
+  cacheDB = new lmdb.open("cache.lmdb", {
+    compression: true,
+  });
 };
 
 exports.runTest = async function (test) {
   let { attrs, contents, file } = test;
   const isModule = attrs.flags.module;
 
+  const cacheKey = sha1(JSON.stringify({ attrs, file }));
+
   try {
-    contents = transpile(contents, { features: attrs.features, isModule, isStrict: false });
+    contents = transpile(contents, {
+      features: attrs.features,
+      isModule,
+      isStrict: false,
+    });
   } catch (error) {
     return { result: "parser error", error };
+  }
+
+  const testObject = {
+    attrs,
+    contents,
+    file: path.join(testRoot, file),
+  };
+
+  const cacheHash = buildCacheHash(testObject);
+
+  const cacheData = cacheDB?.get(cacheKey);
+  if (cacheData?.hash === cacheHash) {
+    return cacheData.ret;
   }
 
   let result;
   let ret;
   try {
-    result = await Promise.race([
-      agent.evalScript({
-        attrs,
-        contents,
-        file: path.join(testRoot, file),
-      }),
-      timeout(file),
-    ]);
+    result = await Promise.race([agent.evalScript(testObject), timeout(file)]);
+
+    if (result.error) {
+      ret = { result: "runtime error", error: result.error };
+    } else {
+      ret = { result: "success", output: result.stdout };
+    }
   } catch (error) {
     agent.stop(); // kill process avoid 100% cpu usage
 
-    return { result: "timeout error", error };
+    ret = { result: "timeout error", error };
   }
 
-  if (result.error) {
-    ret = { result: "runtime error", error: result.error };
-  } else {
-    ret = { result: "success", output: result.stdout };
-  }
+  cacheDB?.put(cacheKey, { hash: cacheHash, ret });
 
   return ret;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "got": "^11.8.3",
         "highland": "^2.13.5",
         "jest-worker": "^29.1.2",
+        "lmdb": "^3.4.0",
         "make-tap-output": "^2.0.0",
         "progress": "^2.0.3",
         "rimraf": "^3.0.0",
@@ -1906,6 +1907,175 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.4.0.tgz",
+      "integrity": "sha512-VP7cMUlyXvmClX33iM21tKRyTZFCJGZg1YSQIcAXwWxnj7J50+Tqs9KhDjCSuMu4WHLWF59ATIlLD1MKgogYDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.4.0.tgz",
+      "integrity": "sha512-h97XIhEwO1uczrX4rLDo0QEgyB8MmawEjvLqjXucDRlpvOGGQALlNYf9DedMdoofLNnMK+mboWvYEcL/Y5Kk6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.4.0.tgz",
+      "integrity": "sha512-2LP+By96O1PG9o1on+3RJlUwD31xMi1VaWlDx8Y7fI6KYeXt89ZkJivDZEWd6KG9D8fNbAcrdkt+9rwFoeNMvg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.4.0.tgz",
+      "integrity": "sha512-3tlodxrfszxOX0M1gkx2pucb++5LfdiHLA2uCLld+UJy6S0oPvqiWgAxUT4CyAX7X0Gy+JT8h0Nv6yDlwnC5EA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.4.0.tgz",
+      "integrity": "sha512-VnpUdqJggi8fc9sI1H50Bsd00ywL0O1OtaNkBYVwhmHlD7elaTElpbLo6FDEyCND3u4zxw061WPWpdgf5TZcuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-win32-arm64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.4.0.tgz",
+      "integrity": "sha512-/17y6BqO09MbhmwPsg+5yN8GlGb3rv7Vt644lhhascLbVYJdmwSdpss0vNqFYwPdVEkmhvwmbXWLeXFaDxSJQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.4.0.tgz",
+      "integrity": "sha512-x3LZ2Zq/lIZLEc3Fv54/6CQg9w/CWGc1cz0p4QFQei/1OmrOB4sZEHgD/miAp8eDAHe0g+KqW13k7S9C0TBFmA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@octokit/auth-token": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
@@ -2495,6 +2665,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -3063,6 +3242,32 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/lmdb": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.4.0.tgz",
+      "integrity": "sha512-vrhkVxu+9IM463hYvozwt/Su70BNo+OvrMBds3isVljd38p5owYOlVvWVpie+//T8YtDaaOL1NDto5oEkEn9CQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "msgpackr": "^1.11.2",
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build-optional-packages": "5.2.2",
+        "ordered-binary": "^1.5.3",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "bin": {
+        "download-lmdb-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "3.4.0",
+        "@lmdb/lmdb-darwin-x64": "3.4.0",
+        "@lmdb/lmdb-linux-arm": "3.4.0",
+        "@lmdb/lmdb-linux-arm64": "3.4.0",
+        "@lmdb/lmdb-linux-x64": "3.4.0",
+        "@lmdb/lmdb-win32-arm64": "3.4.0",
+        "@lmdb/lmdb-win32-x64": "3.4.0"
+      }
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -3189,12 +3394,63 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
+      "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -3221,6 +3477,12 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/ordered-binary": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.3.tgz",
+      "integrity": "sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA==",
+      "license": "MIT"
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
@@ -3996,6 +4258,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
       "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
+    },
+    "node_modules/weak-lru-cache": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
+      "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -5241,6 +5509,84 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@lmdb/lmdb-darwin-arm64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.4.0.tgz",
+      "integrity": "sha512-VP7cMUlyXvmClX33iM21tKRyTZFCJGZg1YSQIcAXwWxnj7J50+Tqs9KhDjCSuMu4WHLWF59ATIlLD1MKgogYDw==",
+      "optional": true
+    },
+    "@lmdb/lmdb-darwin-x64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.4.0.tgz",
+      "integrity": "sha512-h97XIhEwO1uczrX4rLDo0QEgyB8MmawEjvLqjXucDRlpvOGGQALlNYf9DedMdoofLNnMK+mboWvYEcL/Y5Kk6Q==",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.4.0.tgz",
+      "integrity": "sha512-2LP+By96O1PG9o1on+3RJlUwD31xMi1VaWlDx8Y7fI6KYeXt89ZkJivDZEWd6KG9D8fNbAcrdkt+9rwFoeNMvg==",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-arm64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.4.0.tgz",
+      "integrity": "sha512-3tlodxrfszxOX0M1gkx2pucb++5LfdiHLA2uCLld+UJy6S0oPvqiWgAxUT4CyAX7X0Gy+JT8h0Nv6yDlwnC5EA==",
+      "optional": true
+    },
+    "@lmdb/lmdb-linux-x64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.4.0.tgz",
+      "integrity": "sha512-VnpUdqJggi8fc9sI1H50Bsd00ywL0O1OtaNkBYVwhmHlD7elaTElpbLo6FDEyCND3u4zxw061WPWpdgf5TZcuQ==",
+      "optional": true
+    },
+    "@lmdb/lmdb-win32-arm64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.4.0.tgz",
+      "integrity": "sha512-/17y6BqO09MbhmwPsg+5yN8GlGb3rv7Vt644lhhascLbVYJdmwSdpss0vNqFYwPdVEkmhvwmbXWLeXFaDxSJQw==",
+      "optional": true
+    },
+    "@lmdb/lmdb-win32-x64": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.4.0.tgz",
+      "integrity": "sha512-x3LZ2Zq/lIZLEc3Fv54/6CQg9w/CWGc1cz0p4QFQei/1OmrOB4sZEHgD/miAp8eDAHe0g+KqW13k7S9C0TBFmA==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "optional": true
+    },
     "@octokit/auth-token": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
@@ -5685,6 +6031,11 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
     },
+    "detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -6127,6 +6478,25 @@
         "immediate": "~3.0.5"
       }
     },
+    "lmdb": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.4.0.tgz",
+      "integrity": "sha512-vrhkVxu+9IM463hYvozwt/Su70BNo+OvrMBds3isVljd38p5owYOlVvWVpie+//T8YtDaaOL1NDto5oEkEn9CQ==",
+      "requires": {
+        "@lmdb/lmdb-darwin-arm64": "3.4.0",
+        "@lmdb/lmdb-darwin-x64": "3.4.0",
+        "@lmdb/lmdb-linux-arm": "3.4.0",
+        "@lmdb/lmdb-linux-arm64": "3.4.0",
+        "@lmdb/lmdb-linux-x64": "3.4.0",
+        "@lmdb/lmdb-win32-arm64": "3.4.0",
+        "@lmdb/lmdb-win32-x64": "3.4.0",
+        "msgpackr": "^1.11.2",
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build-optional-packages": "5.2.2",
+        "ordered-binary": "^1.5.3",
+        "weak-lru-cache": "^1.2.2"
+      }
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -6230,10 +6600,46 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "msgpackr": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
+      "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
+      "requires": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "optional": true,
+      "requires": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3",
+        "node-gyp-build-optional-packages": "5.2.2"
+      }
+    },
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+    },
+    "node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "requires": {
+        "detect-libc": "^2.0.1"
+      }
     },
     "node-releases": {
       "version": "2.0.18",
@@ -6252,6 +6658,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "ordered-binary": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.3.tgz",
+      "integrity": "sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA=="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -6865,6 +7276,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
       "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA=="
+    },
+    "weak-lru-cache": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
+      "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "got": "^11.8.3",
     "highland": "^2.13.5",
     "jest-worker": "^29.1.2",
+    "lmdb": "^3.4.0",
     "make-tap-output": "^2.0.0",
     "progress": "^2.0.3",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
Compilation results are not cached, which ensures that Babel changes are reflected in a timely manner.
There is a simple list to skip caching for tests that use other files.

