### PR TITLE
fix: Eval correctly returns `undefined`

### DIFF
--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -36,7 +36,7 @@ function getOptions(features, isModule) {
 module.exports = function transpile(code, { features, isModule, isStrict } = {}) {
   if (isStrict && !isModule && !/^\s*['"]use strict['"]/.test(code)) {
     // eval("") === undefined
-    code = `"use strict";\nundefined;${code}`;
+    code = `"use strict";\nundefined;\n${code}`;
   }
   const ret = transformSync(code, getOptions(features || [], Boolean(isModule))).code;
   return ret;

--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -35,7 +35,8 @@ function getOptions(features, isModule) {
 
 module.exports = function transpile(code, { features, isModule, isStrict } = {}) {
   if (isStrict && !isModule && !/^\s*['"]use strict['"]/.test(code)) {
-    code = `"use strict";\n${code}`;
+    // eval("") === undefined
+    code = `"use strict";\nundefined;${code}`;
   }
   const ret = transformSync(code, getOptions(features || [], Boolean(isModule))).code;
   return ret;


### PR DESCRIPTION
Ref: https://github.com/babel/babel-test262-runner/pull/57
```
not ok 2572 test/language/statementList/eval-block-block.js strict mode # (expected success, got runtime error)
  ---
  name: Test262Error
  message: 'Expected SameValue(«use strict», «undefined») to be true'
  stack: >
    Test262Error: Expected SameValue(«use strict», «undefined») to be true

    /home/runner/work/babel/babel/babel-test[26](https://github.com/babel/babel/actions/runs/8562900599/job/23467365029?pr=16410#step:14:27)2-runner/lib/run-tests/index.js:80:17
```