### PR TITLE
Improve download-main-artifact

### DIFF
--- a/lib/download-main-artifact/index.mjs
+++ b/lib/download-main-artifact/index.mjs
@@ -16,7 +16,7 @@ const {
 const octokit = new Octokit({ auth: GITHUB_TOKEN })
 
 let artifact;
-for (let page = 1;; page++) {
+for (let page = 1; page < 100; page++) {
     const { workflow_runs: [workflow] } = await octokit.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs?branch={branch}&per_page=1&page={page}', {
         workflow_id: WORKFLOW_NAME,
         owner: REPO_OWNER,

--- a/lib/download-main-artifact/index.mjs
+++ b/lib/download-main-artifact/index.mjs
@@ -8,24 +8,22 @@ const {
     REPO_OWNER = 'babel',
     REPO_NAME = 'babel',
     BRANCH = 'main',
-    WORKFLOW_NAME = 'CI',
+    WORKFLOW_NAME = 'ci.yml',
     ARTIFACT_NAME = 'test262-result',
     ARTIFACT_FILE = 'test262.tap',
 } = process.env;
 
 const octokit = new Octokit({ auth: GITHUB_TOKEN })
 
-
-const { workflow_runs } = await octokit.request('GET /repos/{owner}/{repo}/actions/runs?branch={branch}&per_page=100&name=test262', {
-    owner: REPO_OWNER,
-    repo: REPO_NAME,
-    branch: BRANCH
-}).then(handleErrors);
-
 let artifact;
-for (const workflow of workflow_runs) {
-    if (workflow.name !== WORKFLOW_NAME) continue;
-
+for (let page = 1;; page++) {
+    const { workflow_runs: [workflow] } = await octokit.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs?branch={branch}&per_page=1&page={page}', {
+        workflow_id: WORKFLOW_NAME,
+        owner: REPO_OWNER,
+        repo: REPO_NAME,
+        branch: BRANCH,
+        page: page
+    }).then(handleErrors);
     const { artifacts } = await octokit.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts', {
         owner: REPO_OWNER,
         repo: REPO_NAME,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3678,9 +3678,9 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.5.0.tgz",
-      "integrity": "sha512-gGunfS0od3VpwDBpGwVkzSZx6Aqo9uOcf1afJj2cKnKFAoyl16fvhpsUhmUFd4Ldbvl5JvRQed6eQw6oQp6n8w==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.5.1.tgz",
+      "integrity": "sha512-eaTE4tBKRD6RFoetquMbxgvcpvoDtRyIlkIMI/SMK2bsKvbENTsDeeu4GJ/z9c90yOWxB7b/eC+yKLPbHnH6bA==",
       "dependencies": {
         "debug": "~4.1.0",
         "engine.io": "~3.6.0",
@@ -6773,9 +6773,9 @@
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "socket.io": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.5.0.tgz",
-      "integrity": "sha512-gGunfS0od3VpwDBpGwVkzSZx6Aqo9uOcf1afJj2cKnKFAoyl16fvhpsUhmUFd4Ldbvl5JvRQed6eQw6oQp6n8w==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.5.1.tgz",
+      "integrity": "sha512-eaTE4tBKRD6RFoetquMbxgvcpvoDtRyIlkIMI/SMK2bsKvbENTsDeeu4GJ/z9c90yOWxB7b/eC+yKLPbHnH6bA==",
       "requires": {
         "debug": "~4.1.0",
         "engine.io": "~3.6.0",


### PR DESCRIPTION
This PR responds to recent Babel CI errors:

https://github.com/babel/babel/actions/runs/10024412764/job/27706628250
https://github.com/babel/babel/actions/runs/10023055530/job/27703704666

Previously we are querying 100 recent workflows and then filter the CI workflow, in this PR we query only the last CI workflow , and then fallback to the previous one only when we didn't find an artifact, which is quite rare. The new API usage should significantly reduce the traffic.