### PR TITLE
Bug when using different agents (d8, newer node versions)

### DIFF
--- a/lib/run-tests/worker.js
+++ b/lib/run-tests/worker.js
@@ -39,7 +39,7 @@ exports.runTest = async function (test) {
         attrs,
         contents,
         file: path.join(testRoot, file),
-      }),
+      }, { module: isModule ? isModule : undefined }),
       timeout(file),
     ]);
   } catch (error) {


### PR DESCRIPTION
Note: [This does not affect the current node backend, I just stumbled upon it when changing the backend to d8]

The spawned processes by `evalScript` may fail to to pass the flags needed to indicate module code. This change might be relevant if the backend is changed/updated in the future.

**Before**
```bash
TAP version 13
# Using 128 threads.
SPAWNED PROCESS CMD:  /home/meetesh/wd/babel-test262-runner/engine/node/bin/node [
  '--expose-gc', 
   '/tmp/lzeQCNpKeVbOkPsgz3xc/eval-export-gen-semi.js' 
] { detached: true }
SPAWNED PROCESS CMD:  /home/meetesh/wd/babel-test262-runner/engine/node/bin/node [
  '--expose-gc',
  '/tmp/R9oDTzDfXLcEkFIpEJWY/eval-export-gen-semi.js' 
] { detached: true }
ok 1 test/language/module-code/eval-export-gen-semi.js strict mode # (success)
ok 2 test/language/module-code/eval-export-gen-semi.js default # (success)
# 
# 
# 
# Run 2 out of 44598 tests.
# Passed 2 out of 2 tests.

```

**After**
```bash
TAP version 13
# Using 128 threads.
SPAWNED PROCESS CMD:  /home/meetesh/wd/babel-test262-runner/engine/node/bin/node [
  '--experimental-modules', // <-- Missed Earlier
  '--expose-gc',
  '/tmp/4X5ib3ZucDotcJYRrhYJ/eval-export-gen-semi.js'
] { detached: true }
SPAWNED PROCESS CMD:  /home/meetesh/wd/babel-test262-runner/engine/node/bin/node [
  '--experimental-modules', // <-- Missed Earlier
  '--expose-gc',
  '/tmp/jdi2NMnBjIunpcrU39es/eval-export-gen-semi.js'
] { detached: true }
ok 1 test/language/module-code/eval-export-gen-semi.js default # (success)
ok 2 test/language/module-code/eval-export-gen-semi.js strict mode # (success)
# 
# 
# 
# Run 2 out of 44598 tests.
# Passed 2 out of 2 tests.
```