### PR TITLE
Set `targets` to `node v0.10`

### DIFF
--- a/lib/run-tests/transpile.js
+++ b/lib/run-tests/transpile.js
@@ -23,7 +23,7 @@ function getOptions(features, isModule) {
   config = loadOptionsSync({
     configFile: false,
     babelrc: false,
-    targets: ">= 0%",
+    targets: "node 0.10",
     presets: [presetEnv],
     // spec
     assumptions: {


### PR DESCRIPTION
This avoids us performing ES3 identifier conversion, which would cause some eval tests to fail.